### PR TITLE
feat(SCRUM-6): 닉네임 등록 및 유저 정보 상태 저장 기능 구현

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,25 @@
+import axios from './axiosInstance';
+
+/**
+ * 닉네임 중복 확인 API
+ * @param nickname 확인할 닉네임
+ * @returns true → 중복 있음 / false → 사용 가능
+ */
+export const checkNicknameDuplicate = async (
+  nickname: string,
+): Promise<boolean> => {
+  const res = await axios.get('/api/v1/user/check-nickname', {
+    params: { nickname },
+  });
+  return res.data.exists; // 👈 백엔드 응답 형식에 따라 조정
+};
+
+/**
+ * 닉네임 등록 API
+ * @param nickname 저장할 닉네임
+ * @returns 등록된 유저 정보 (예: id, nickname)
+ */
+export const registerNickname = async (nickname: string) => {
+  const res = await axios.patch('/api/v1/user/nickname', { nickname });
+  return res.data.results; // 👈 CallbackPage나 Redux에서 쓰이는 유저 정보 반환
+};

--- a/src/pages/auth/NicknamePage.tsx
+++ b/src/pages/auth/NicknamePage.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { checkNicknameDuplicate, registerNickname } from '@/api/user'; // ✅ ❶ axios 기반 API 함수 import
+import { useDispatch } from 'react-redux';
+// import { setUser } from '@/store/authSlice'; // ✅ ❷ 닉네임 저장용 액션
+
 export default function NicknamePage() {
   const navigate = useNavigate();
+  const dispatch = useDispatch(); // ✅ ❷ 리덕스 상태 갱신용
 
   const [nickname, setNickname] = useState('');
   const [error, setError] = useState('');
@@ -27,16 +32,59 @@ export default function NicknamePage() {
     setIsDuplicate(null); // 닉네임 변경 시 중복 확인 초기화
   };
 
-  // 중복 확인
+  // // 중복 확인
+  // const checkDuplicate = async () => {
+  //   if (error || nickname.length === 0) return;
+
+  //   setIsChecking(true);
+  //   try {
+  //     const res = await fetch(`/api/check-nickname?nickname=${nickname}`);
+  //     const data = await res.json();
+
+  //     if (data.exists) {
+  //       setIsDuplicate(true);
+  //       setError('이미 사용 중인 닉네임이에요');
+  //     } else {
+  //       setIsDuplicate(false);
+  //       setError('');
+  //     }
+  //   } catch {
+  //     setError('중복 확인 중 오류가 발생했어요');
+  //   } finally {
+  //     setIsChecking(false);
+  //   }
+  // };
+
+  // // 닉네임 등록
+  // const registerNickname = async () => {
+  //   if (!!error || isDuplicate !== false) return;
+
+  //   setIsSubmitting(true);
+  //   try {
+  //     const res = await fetch('/api/register-nickname', {
+  //       method: 'POST',
+  //       headers: { 'Content-Type': 'application/json' },
+  //       body: JSON.stringify({ nickname }),
+  //     });
+
+  //     if (!res.ok) throw new Error();
+
+  //     // 성공 시 다음 페이지로 이동
+  //     navigate('/home'); // 필요시 '/welcome' 등으로 변경 가능
+  //   } catch {
+  //     setError('닉네임 등록 중 오류가 발생했어요');
+  //   } finally {
+  //     setIsSubmitting(false);
+  //   }
+  // };
+  // ✅ ❶ 중복 확인 - fetch → axios 사용 & api/user.ts 함수로 분리
   const checkDuplicate = async () => {
     if (error || nickname.length === 0) return;
 
     setIsChecking(true);
     try {
-      const res = await fetch(`/api/check-nickname?nickname=${nickname}`);
-      const data = await res.json();
-
-      if (data.exists) {
+      const exists = await checkNicknameDuplicate(nickname); // 👈 boolean 값 반환
+      if (exists) {
         setIsDuplicate(true);
         setError('이미 사용 중인 닉네임이에요');
       } else {
@@ -50,22 +98,15 @@ export default function NicknamePage() {
     }
   };
 
-  // 닉네임 등록
-  const registerNickname = async () => {
+  // ✅ ❷ 닉네임 등록 - fetch → axios 사용 & 상태 저장 + 리디렉션
+  const handleRegister = async () => {
     if (!!error || isDuplicate !== false) return;
 
     setIsSubmitting(true);
     try {
-      const res = await fetch('/api/register-nickname', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nickname }),
-      });
-
-      if (!res.ok) throw new Error();
-
-      // 성공 시 다음 페이지로 이동
-      navigate('/home'); // 필요시 '/welcome' 등으로 변경 가능
+      const result = await registerNickname(nickname); // 👈 서버에서 등록 후 유저 정보 반환
+      dispatch(setUser({ id: result.id, nickname: result.nickname })); // ✅ 리덕스에 저장
+      navigate('/'); // 홈으로 이동
     } catch {
       setError('닉네임 등록 중 오류가 발생했어요');
     } finally {
@@ -118,7 +159,7 @@ export default function NicknamePage() {
       {/* 하단 고정 버튼 */}
       <div className="mt-auto">
         <button
-          onClick={registerNickname}
+          onClick={handleRegister}
           disabled={!!error || isDuplicate !== false || isSubmitting}
           className={`w-full rounded-xl py-4 text-base font-semibold transition ${
             !!error || isDuplicate !== false || isSubmitting

--- a/src/pages/auth/NicknamePage.tsx
+++ b/src/pages/auth/NicknamePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { checkNicknameDuplicate, registerNickname } from '@/api/user'; // ✅ ❶ axios 기반 API 함수 import
 import { useDispatch } from 'react-redux';
-// import { setUser } from '@/store/authSlice'; // ✅ ❷ 닉네임 저장용 액션
+import { setUser } from '@/store/authSlice'; // ✅ ❷ 닉네임 저장용 액션
 
 export default function NicknamePage() {
   const navigate = useNavigate();
@@ -32,52 +32,7 @@ export default function NicknamePage() {
     setIsDuplicate(null); // 닉네임 변경 시 중복 확인 초기화
   };
 
-  // // 중복 확인
-  // const checkDuplicate = async () => {
-  //   if (error || nickname.length === 0) return;
-
-  //   setIsChecking(true);
-  //   try {
-  //     const res = await fetch(`/api/check-nickname?nickname=${nickname}`);
-  //     const data = await res.json();
-
-  //     if (data.exists) {
-  //       setIsDuplicate(true);
-  //       setError('이미 사용 중인 닉네임이에요');
-  //     } else {
-  //       setIsDuplicate(false);
-  //       setError('');
-  //     }
-  //   } catch {
-  //     setError('중복 확인 중 오류가 발생했어요');
-  //   } finally {
-  //     setIsChecking(false);
-  //   }
-  // };
-
-  // // 닉네임 등록
-  // const registerNickname = async () => {
-  //   if (!!error || isDuplicate !== false) return;
-
-  //   setIsSubmitting(true);
-  //   try {
-  //     const res = await fetch('/api/register-nickname', {
-  //       method: 'POST',
-  //       headers: { 'Content-Type': 'application/json' },
-  //       body: JSON.stringify({ nickname }),
-  //     });
-
-  //     if (!res.ok) throw new Error();
-
-  //     // 성공 시 다음 페이지로 이동
-  //     navigate('/home'); // 필요시 '/welcome' 등으로 변경 가능
-  //   } catch {
-  //     setError('닉네임 등록 중 오류가 발생했어요');
-  //   } finally {
-  //     setIsSubmitting(false);
-  //   }
-  // };
-  // ✅ ❶ 중복 확인 - fetch → axios 사용 & api/user.ts 함수로 분리
+  // ✅ ❶ 닉네임 중복 확인 : fetch → axios 사용 & api/user.ts 함수로 분리
   const checkDuplicate = async () => {
     if (error || nickname.length === 0) return;
 
@@ -98,14 +53,19 @@ export default function NicknamePage() {
     }
   };
 
-  // ✅ ❷ 닉네임 등록 - fetch → axios 사용 & 상태 저장 + 리디렉션
+  // ✅ ❷ 닉네임 등록 : fetch → axios 사용 & 상태 저장 + 리디렉션
   const handleRegister = async () => {
     if (!!error || isDuplicate !== false) return;
 
     setIsSubmitting(true);
     try {
-      const result = await registerNickname(nickname); // 👈 서버에서 등록 후 유저 정보 반환
-      dispatch(setUser({ id: result.id, nickname: result.nickname })); // ✅ 리덕스에 저장
+      const result = await registerNickname(nickname); // 서버에서 등록 후 유저 정보 반환
+      dispatch(setUser({ id: result.email, nickname: result.nickname })); // nickname, email 받아서 Redux에 저장
+
+      // ✅ 선택: 새로고침에도 유지하고 싶다면 localStorage에도 저장
+      // localStorage.setItem('nickname', result.nickname);
+      // localStorage.setItem('email', result.email);
+
       navigate('/'); // 홈으로 이동
     } catch {
       setError('닉네임 등록 중 오류가 발생했어요');

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,4 +1,3 @@
-// src/store/authSlice.ts
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface AuthState {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,3 @@
-// src/store/index.ts
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './authSlice';
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './authSlice';
+import userReducer from './userSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    user: userReducer,
   },
 });
 

--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface UserState {
+  id: string | null; // 이메일 (social login id)
+  nickname: string | null; // 유저 닉네임
+  isLoggedIn: boolean; // 로그인 여부
+}
+
+const initialState: UserState = {
+  id: null,
+  nickname: null,
+  isLoggedIn: false,
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    // ✅ 유저 정보 저장 (닉네임 등록 시 호출됨)
+    setUser: (
+      state,
+      action: PayloadAction<{ id: string; nickname: string }>,
+    ) => {
+      state.id = action.payload.id;
+      state.nickname = action.payload.nickname;
+      state.isLoggedIn = true;
+    },
+
+    // ✅ 로그아웃 또는 유저 정보 초기화
+    clearUser: (state) => {
+      state.id = null;
+      state.nickname = null;
+      state.isLoggedIn = false;
+    },
+  },
+});
+
+export const { setUser, clearUser } = userSlice.actions;
+export default userSlice.reducer;


### PR DESCRIPTION
### 🧩 작업 배경
소셜 로그인 이후 닉네임을 최초 등록하는 단계에서,  
등록한 닉네임과 로그인 계정(email)을 앱 전체에서 사용할 수 있도록 전역 상태에 저장할 필요가 있었습니다.

---

### ✅ 주요 구현 내용
- **닉네임 중복 확인 API 연동**
  - `/api/v1/user/check-nickname` 호출하여 사용 가능 여부 판단
- **닉네임 등록 API 연동**
  - `/api/v1/user/nickname` PATCH 요청
  - 백엔드 응답에서 `nickname`, `email`을 받아 전역 상태로 저장
- **전역 유저 상태 관리용 `userSlice` 생성**
  - `id`(= email), `nickname`, `isLoggedIn` 포함
  - `setUser`, `clearUser` reducer 추가

---

### 📦 전역 상태 저장 흐름
1. 닉네임 등록 성공 시 `results.nickname`, `results.email` 응답 수신
2. `dispatch(setUser(...))`를 통해 Redux 상태 업데이트
3. 이후 탑바/마이페이지 등에서 `useSelector`로 nickname/email 사용 가능

---

### 🧪 테스트 및 확인 항목
- [x] 닉네임 유효성 검사 및 중복 확인 정상 동작
- [x] 등록 완료 시 Redux 상태에 nickname, email 반영됨
- [x] 홈 화면으로 정상 이동

---

### 📝 기타사항
- 백엔드에 `닉네임 등록 API` 응답에 `email`, `nickname` 포함 요청 완료
- 현재 응답 구조가 아직 반영되지 않아 `result.nickname`, `result.email`에서 오류가 발생할 수 있음
- 백엔드 반영 이후 결과 필드를 정상적으로 참조하도록 유지보수 예정
- nickname/email 새로고침 유지용 localStorage 저장은 추후 반영 고려