### PR TITLE
feat(SCRUM-148): 편의점 상세 페이지 브랜드/카테고리 한국어 매핑 적용

### DIFF
--- a/src/pages/convenience/AddConveniencePage.tsx
+++ b/src/pages/convenience/AddConveniencePage.tsx
@@ -7,7 +7,7 @@ import { toServerCategory, toServerBrand } from '@/types/convenienceMapper';
 
 import ButtonGroup from '@/components/ConvenienceStore/ButtonGroup';
 import TopBar from '@/components/common/TopBar';
-import SelectableButton from '@/pages/convenience/SelectableButton';
+import SelectableButton from '@/components/ConvenienceStore/SelectableButton';
 
 import vectorIcon from '@/assets/svgs/convenience/vector.svg';
 

--- a/src/pages/convenience/ConvenienceDetailPage.tsx
+++ b/src/pages/convenience/ConvenienceDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   submitPostFeedback,
   deleteConveniencePost,
 } from '@/api/convenience';
+import { fromServerBrand, fromServerCategory } from '@/types/convenienceMapper';
 
 import TopBar from '@/components/common/TopBar';
 import DeleteConvenience from '@/components/ConvenienceStore/DeleteConvenience';
@@ -131,10 +132,10 @@ export default function ConvenienceDetailPage() {
         {/* 카테고리 및 브랜드 pill */}
         <div className="flex gap-2 mt-2">
           <div className="border-[#919191] border-[1.5px] leading-[1] rounded-[12px] px-5 py-1 bg-[#F4F6F8]">
-            {post.category}
+            {fromServerCategory(post.category)}
           </div>
           <div className="border-[#919191] border-[1.5px] leading-[1] rounded-[12px] px-5 py-1 bg-[#F4F6F8]">
-            {post.brand}
+            {fromServerBrand(post.brand)}
           </div>
         </div>
 

--- a/src/pages/convenience/ConveniencePage.tsx
+++ b/src/pages/convenience/ConveniencePage.tsx
@@ -6,10 +6,10 @@ import SearchInput from '@/components/common/SearchInput';
 import TopBar from '@/components/common/TopBar';
 import InfoShareCard from '@/components/ConvenienceStore/InfoShareCard';
 
-import ProductListSection from './ProductListSection';
+import ProductListSection from '../../components/ConvenienceStore/ProductListSection';
 import ButtonGroup from '../../components/ConvenienceStore/ButtonGroup';
-import Check from './Check';
-import CategoryFilterSelector from './CategoryFilterSelector';
+import Check from '../../components/ConvenienceStore/Check';
+import CategoryFilterSelector from '../../components/ConvenienceStore/CategoryFilterSelector';
 
 const ConvenienceStorePage = () => {
   const [products, setProducts] = useState([]); // 편의점 제품 목록 상태

--- a/src/types/convenienceMapper.ts
+++ b/src/types/convenienceMapper.ts
@@ -21,3 +21,27 @@ export const toServerBrand = (label: string): string | undefined => {
   };
   return map[label];
 };
+
+// 영어 → 한글: 카테고리
+export const fromServerCategory = (code: string): string => {
+  const map: Record<string, string> = {
+    MEAL: '식사류',
+    SNACK: '간식류',
+    DRINK: '음료',
+    FRUIT: '과일류',
+    ETC: '기타',
+  };
+  return map[code] || code;
+};
+
+// 영어 → 한글: 브랜드
+export const fromServerBrand = (code: string): string => {
+  const map: Record<string, string> = {
+    GS25: 'GS25',
+    CU: 'CU',
+    SEVEN_ELEVEN: '세븐일레븐',
+    EMART_24: '이마트24',
+    MINI_STOP: '미니스톱',
+  };
+  return map[code] || code;
+};


### PR DESCRIPTION
- 상세 조회 API에서 응답받은 영문 브랜드/카테고리 값을 한국어로 변환하여 UI에 출력
- toClientBrand, toClientCategory 유틸 함수 추가
- 상세 페이지 내 브랜드, 카테고리 출력 부분에 매핑 적용